### PR TITLE
fix(phrasebook): separate persisted phrasebook slice

### DIFF
--- a/src/modules/phrasebook/components/index.ts
+++ b/src/modules/phrasebook/components/index.ts
@@ -4,3 +4,4 @@ export * from './phrase-card-item';
 export * from './bottom-sheet-options-menu-phrase-list';
 export { default as BottomSheetPhraseDetail } from './bottom-sheet-phrase-detail';
 export { default as BottomSheetPhrasebookCategoryList } from './bottom-sheet-phrasebook-category-list';
+export { default as FloatingButtonAddPhrase } from './floating-button-add-phrase';

--- a/src/modules/phrasebook/hooks/use-phrasebook.hook.ts
+++ b/src/modules/phrasebook/hooks/use-phrasebook.hook.ts
@@ -1,10 +1,17 @@
 import { useAppSelector } from '@/plugins/redux';
 
 // app slice
-import { phrasebook_selector, phrasebook_reducerActions, phrasebookApi } from '@/modules/phrasebook/redux';
+import {
+  phrasebook_selector,
+  phrasebook_reducerActions,
+  phrasebookApi,
+  phrasebookPersisted_selector,
+  phrasebookPersisted_reducerActions,
+} from '@/modules/phrasebook/redux';
 
 export const usePhrasebook = () => {
-  const appState = useAppSelector(phrasebook_selector);
+  const phrasebookState = useAppSelector(phrasebook_selector);
+  const phrasebookPersistedState = useAppSelector(phrasebookPersisted_selector);
 
   const [
     phrasebook_getListCategory,
@@ -20,8 +27,10 @@ export const usePhrasebook = () => {
     phrasebookApi.useCreatePhraseMutation();
 
   return {
-    ...appState,
+    ...phrasebookState,
     ...phrasebook_reducerActions,
+    ...phrasebookPersistedState,
+    ...phrasebookPersisted_reducerActions,
     phrasebook_getListCategory,
     phrasebook_getListCategoryData,
     phrasebook_getListCategoryIsLoading,

--- a/src/modules/phrasebook/redux/index.ts
+++ b/src/modules/phrasebook/redux/index.ts
@@ -1,2 +1,3 @@
 export * from './phrasebook.slice';
+export * from './phrasebook.persisted.slice';
 export * from './phrasebook.api';

--- a/src/modules/phrasebook/redux/phrasebook.persisted.slice.ts
+++ b/src/modules/phrasebook/redux/phrasebook.persisted.slice.ts
@@ -1,0 +1,46 @@
+// redux toolkit
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+// types
+import { RootState } from '@/plugins/redux';
+import { IPhrasebook, IPhraseCategory } from '@/modules/phrasebook/interfaces';
+
+// type for our state
+export type PhrasebookPersistedSliceState = {
+  listCategories: Array<IPhraseCategory>;
+  listPhrasebook: {
+    [key: string]: IPhrasebook;
+  };
+};
+
+// initial state
+export const phrasebookPersisted_initialState: PhrasebookPersistedSliceState = {
+  listCategories: [],
+  listPhrasebook: {},
+};
+
+export const phrasebookPersistedSlice = createSlice({
+  name: 'phrasebook.persisted',
+  initialState: phrasebookPersisted_initialState,
+  reducers: {
+    phrasebookPersisted_setListCategories(state, action: PayloadAction<Array<IPhraseCategory>>) {
+      state.listCategories = action.payload?.length > 0 ? action.payload : [];
+    },
+    phrasebookPersisted_setListPhrasebook(state, action: PayloadAction<IPhrasebook>) {
+      if (action.payload?.category?.id) {
+        state.listPhrasebook = {
+          ...state.listPhrasebook,
+          [action.payload.category.id]: action.payload,
+        };
+      }
+    },
+    phrasebookPersisted_reset() {
+      return phrasebookPersisted_initialState;
+    },
+  },
+});
+
+export const phrasebookPersisted_reducerActions = phrasebookPersistedSlice.actions;
+
+export const phrasebookPersisted_selector = (state: RootState): PhrasebookPersistedSliceState =>
+  state['phrasebook.persisted'];

--- a/src/modules/phrasebook/redux/phrasebook.slice.ts
+++ b/src/modules/phrasebook/redux/phrasebook.slice.ts
@@ -3,15 +3,10 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 // types
 import { RootState } from '@/plugins/redux';
-import { IPhrase, IPhrasebook, IPhraseCategory } from '@/modules/phrasebook/interfaces';
+import { IPhrase } from '@/modules/phrasebook/interfaces';
 
 // type for our state
 export type PhrasebookSliceState = {
-  listCategories: Array<IPhraseCategory>;
-  listPhrasebook: {
-    [key: string]: IPhrasebook;
-  };
-
   snapIndexBottomSheetCategoryList: number;
   snapIndexBottomSheetDetail: number;
   bottomSheetDetailData: IPhrase | null;
@@ -19,9 +14,6 @@ export type PhrasebookSliceState = {
 
 // initial state
 export const phrasebook_initialState: PhrasebookSliceState = {
-  listCategories: [],
-  listPhrasebook: {},
-
   /**
    * Initial snap point index bottom sheet category list, default should be `-1` to initiate bottom sheet in closed state.
    */
@@ -34,18 +26,6 @@ export const phrasebookSlice = createSlice({
   name: 'phrasebook',
   initialState: phrasebook_initialState,
   reducers: {
-    phrasebook_setListCategories(state, action: PayloadAction<Array<IPhraseCategory>>) {
-      state.listCategories = action.payload?.length > 0 ? action.payload : [];
-      // state.listCategories = action.payload?.length > 0 ? action.payload.sort((a, b) => a.order - b.order)  : [];
-    },
-    phrasebook_setListPhrasebook(state, action: PayloadAction<IPhrasebook>) {
-      if (action.payload?.category?.id) {
-        state.listPhrasebook = {
-          ...state.listPhrasebook,
-          [action.payload.category.id]: action.payload,
-        };
-      }
-    },
     phrasebook_setSnapIndexBottomSheetCategoryList(state, action: PayloadAction<number>) {
       state.snapIndexBottomSheetCategoryList = action.payload;
     },

--- a/src/modules/phrasebook/screens/add-phrase.screen.tsx
+++ b/src/modules/phrasebook/screens/add-phrase.screen.tsx
@@ -24,13 +24,14 @@ const { width: SCREEN_WIDTH } = Dimensions.get('screen');
 const AddPhraseScreen: FC = () => {
   const theme = useTheme();
   const dispatch = useDispatch();
-  const { listCategories, phrasebook_getListCategory, phrasebook_setListCategories } = usePhrasebook();
+  const { listCategories, phrasebook_getListCategory, phrasebookPersisted_setListCategories } = usePhrasebook();
   const navigation = useNavigation<NavigationProps>();
+
   const fetchPhrasebookCategory = async (): Promise<void> => {
     try {
       const response = await phrasebook_getListCategory(undefined);
       if (response.isSuccess) {
-        dispatch(phrasebook_setListCategories(response.data));
+        dispatch(phrasebookPersisted_setListCategories(response.data));
       }
     } catch (e) {
       console.log('e', e);

--- a/src/modules/phrasebook/screens/phrase-category.screen.tsx
+++ b/src/modules/phrasebook/screens/phrase-category.screen.tsx
@@ -38,7 +38,7 @@ const PhraseCategoryScreen: FC = () => {
 
   const {
     listCategories,
-    phrasebook_setListCategories,
+    phrasebookPersisted_setListCategories,
     phrasebook_getListCategory,
     phrasebook_getListCategoryIsLoading,
   } = usePhrasebook();
@@ -62,7 +62,7 @@ const PhraseCategoryScreen: FC = () => {
     try {
       const response = await phrasebook_getListCategory(undefined);
       if (response.isSuccess) {
-        dispatch(phrasebook_setListCategories(response.data));
+        dispatch(phrasebookPersisted_setListCategories(response.data));
       }
     } catch (e) {}
   };

--- a/src/modules/phrasebook/screens/phrase-list.screen.tsx
+++ b/src/modules/phrasebook/screens/phrase-list.screen.tsx
@@ -1,5 +1,5 @@
-import React, { FC, useCallback, useMemo, useState } from 'react';
-import { ActivityIndicator, Dimensions, ListRenderItem, Pressable, FlatList, StyleSheet, View } from 'react-native';
+import React, { useCallback, useMemo, useState } from 'react';
+import { ActivityIndicator, ListRenderItem, Pressable, FlatList, StyleSheet, View } from 'react-native';
 
 // Core components
 import { IconButton, Screen, Typography } from '@/components/core';
@@ -9,15 +9,10 @@ import { EmptyState } from '@/components/shared';
 
 // Components
 import { Ionicons } from '@/components/core';
-import {
-  BottomSheetOptionsMenuPhraseList,
-  BottomSheetPhraseDetail,
-  BottomSheetPhrasebookCategoryList,
-  PhraseCardItem,
-} from '@/modules/phrasebook/components';
+import { BottomSheetPhrasebookCategoryList, PhraseCardItem } from '@/modules/phrasebook/components';
 
 // Hooks
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
+// import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import { usePhrasebook } from '@/modules/phrasebook/hooks';
 import { useTheme } from '@/modules/theme/hooks';
@@ -33,12 +28,12 @@ import { themeConfig } from '@/modules/theme/configs';
 import { IPhrase, IPhraseCategory } from '@/modules/phrasebook/interfaces';
 import { UUID } from '@/modules/common/interfaces';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
-import { platformUtils, screenUtils } from '@/modules/app/utilities';
+import { screenUtils } from '@/modules/app/utilities';
 import { NavigationProps, NavigatorParamList } from '@/navigators';
 import { useAppDispatch } from '@/plugins/redux';
 import { useToast } from '@/modules/app/hooks';
 import { paletteLibs } from '@/modules/theme/libs';
-import FloatingButtonAddPhrase from '../components/floating-button-add-phrase';
+import { FloatingButtonAddPhrase, BottomSheetPhraseDetail } from '@/modules/phrasebook/components';
 
 type Props = NativeStackScreenProps<NavigatorParamList, 'phrase_list_screen'>;
 
@@ -50,7 +45,7 @@ const PhraseListScreen = ({ route }: Props) => {
   const dispatch = useAppDispatch();
   const navigation = useNavigation<NavigationProps>();
 
-  const insets = useSafeAreaInsets();
+  // const insets = useSafeAreaInsets();
 
   const paramsCategory = route.params.category;
 
@@ -58,12 +53,11 @@ const PhraseListScreen = ({ route }: Props) => {
     listPhrasebook,
     phrasebook_getListPhrase,
     phrasebook_getListPhraseIsLoading,
-    phrasebook_setListPhrasebook,
+    phrasebookPersisted_setListPhrasebook,
     snapIndexBottomSheetCategoryList,
     phrasebook_setSnapIndexBottomSheetCategoryList,
   } = usePhrasebook();
 
-  const [showOptionsMenu, setShowOptionsMenu] = useState<boolean>(false);
   const [selectedItems, setSelectedItems] = useState<Array<UUID>>([]);
 
   const listPhases = useMemo(() => {
@@ -77,10 +71,9 @@ const PhraseListScreen = ({ route }: Props) => {
    */
   const getPhraseListByCategory = async (category: IPhraseCategory): Promise<void> => {
     try {
-      console.log('CALL ME ->');
       const result = await phrasebook_getListPhrase({ category: category.slug, limit: null });
       if (result.isSuccess) {
-        dispatch(phrasebook_setListPhrasebook(result.data));
+        dispatch(phrasebookPersisted_setListPhrasebook(result.data));
       }
     } catch (e) {
       showToast({

--- a/src/plugins/redux/config-store.ts
+++ b/src/plugins/redux/config-store.ts
@@ -31,13 +31,13 @@ import { persistStorage } from './persist-storage';
 import { appApi } from '@/modules/app/redux';
 import { baseApi } from '@/plugins/redux/base.api';
 import { authApi, authSlice } from '@/modules/auth/redux';
-import { phrasebookApi, phrasebookSlice } from '@/modules/phrasebook/redux';
+import { phrasebookApi, phrasebookPersistedSlice } from '@/modules/phrasebook/redux';
 
 // persist config
 const persistConfig: PersistConfig<RootState> = {
   key: '@ROOT',
   storage: persistStorage,
-  whitelist: [authSlice.name, phrasebookSlice.name],
+  whitelist: [authSlice.name, phrasebookPersistedSlice.name],
 };
 
 // make persisted store

--- a/src/plugins/redux/root-reducer.ts
+++ b/src/plugins/redux/root-reducer.ts
@@ -6,6 +6,7 @@ import { appApi, appSlice } from '@/modules/app/redux';
 import { settingsSlice } from '@/modules/settings/redux';
 import { authApi, authSlice } from '@/modules/auth/redux';
 import { phrasebookApi, phrasebookSlice } from '@/modules/phrasebook/redux';
+import { phrasebookPersistedSlice } from '@/modules/phrasebook/redux/phrasebook.persisted.slice';
 
 const rootReducer = combineReducers({
   [baseApi.reducerPath]: baseApi.reducer,
@@ -15,6 +16,7 @@ const rootReducer = combineReducers({
   [authApi.reducerPath]: authApi.reducer,
   [settingsSlice.name]: settingsSlice.reducer,
   [phrasebookSlice.name]: phrasebookSlice.reducer,
+  [phrasebookPersistedSlice.name]: phrasebookPersistedSlice.reducer,
   [phrasebookApi.reducerPath]: phrasebookApi.reducer,
 });
 


### PR DESCRIPTION
I found a bug when I entered to the phrasebook list screen the initial bottom sheet immediately opened, this because the phrasebook state rehydrates